### PR TITLE
adding simple readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## Setup
+
+
+```sh
+npm install --save-dev ember-cli-pretender
+bower install -S pretender
+```


### PR DESCRIPTION
because it depends on these files to be in your vendor directory now. Maybe we can now delete `vendor-addon` directory from git?
