### PR TITLE
correct pretender version is 0.4.2, not 0.4.3

### DIFF
--- a/blueprints/ember-cli-pretender/index.js
+++ b/blueprints/ember-cli-pretender/index.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('pretender', '^0.4.3');
+    return this.addBowerPackageToProject('pretender', '^0.4.2');
   }
 };


### PR DESCRIPTION
The [commit message in the pretender repo says 0.4.3](https://github.com/trek/pretender/commit/0a802e8c544bae1ec8a1987d7586388d677bbd91), but in actuality the latest Pretender version was only bumped to 0.4.2.

I moved too fast with the [previous pr](https://github.com/rwjblue/ember-cli-pretender/pull/22), apologies.
