### PR TITLE
update default version of Pretender to 0.6

### DIFF
--- a/blueprints/ember-cli-pretender/index.js
+++ b/blueprints/ember-cli-pretender/index.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('pretender', '^0.4.2');
+    return this.addBowerPackageToProject('pretender', '^0.6.0');
   }
 };


### PR DESCRIPTION
This is currently the latest version of Pretender. It now supports async!