### PR TITLE
Use updated addon install syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 =====
 
 ```sh
-ember install:addon ember-cli-pretender
+ember install ember-cli-pretender
 ```
 
 You can then import Pretender in your tests:


### PR DESCRIPTION
When running this command with 0.2.3 though, there is an error: "The `ember generate` command requires an entity name to be specified. For more details, use `ember help`."

Did something change recently where https://github.com/rwjblue/ember-cli-pretender/blob/master/blueprints/ember-cli-pretender/index.js#L4 is no longer respected? Running `ember g ember-cli-pretender` seems to work ok.