### PR TITLE
Add and document support for being a nested addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ import Pretender from 'pretender';
 
 see: [trek/pretender](https://github.com/trek/pretender) for pretender
 docs
+
+Nested Addon Usage Caveat
+=====
+
+To publish an addon that exports functionality driven by ember-cli-pretender,
+note that ember-cli-pretender must be listed in the `dependencies` for NPM
+and not the `devDependencies`.
+
+When consuming an addon that consumes ember-cli-pretender, running the
+initializing generator by hand is required.
+
+```sh
+ember generate ../node_modules/the-addon/node_modules/ember-cli-pretender/blueprints/ember-cli-pretender
+```

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ module.exports = {
   name: 'ember-cli-pretender',
 
   included: function included(app) {
+    if (app.app) {
+      app = app.app;
+    }
     this.app = app;
 
     if (app.env !== 'production') {
@@ -20,7 +23,6 @@ module.exports = {
 
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
-  },
-
+  }
 
 };


### PR DESCRIPTION
ember-cli-pretender doesn't play happily as a nested addon. This improves support and documents the caveats (which are significant).