### PR TITLE
eliminating duplicate import

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ module.exports = {
 
     if (app.env !== 'production') {
       app.import(app.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js');
-      app.import(app.bowerDirectory + '/route-recognizer/dist/route-recognizer.js');
       app.import(app.bowerDirectory + '/pretender/pretender.js');
       app.import('vendor/ember-cli-pretender/shim.js', {
         type: 'vendor',


### PR DESCRIPTION
This fixes the warning in production builds

Warning: ignoring input sourcemap for bower_components/route-recognizer/dist/route-recognizer.js because ENOENT, no such file or directory '<something>/tmp/tree_merger-tmp_dest_dir-UBptdyy3.tmp/bower_components/route-recognizer/dist/route-recognizer.js.map'


