### PR TITLE
Fix spelling of pretender in configuration section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var app = new EmberApp({
 });
 ```
 
-By default `prentender.enabled` will be set to `app.tests`. This means that prentender will be available as an import when your app includes your test suite.
+By default `pretender.enabled` will be set to `app.tests`. This means that prentender will be available as an import when your app includes your test suite.
 
 Nested Addon Usage Caveat
 =====


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/129756/9092547/cff48f06-3b74-11e5-8589-aad60c624cff.png)
