### PR TITLE
handle the case where Broccoli tree is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ module.exports = {
       pretenderTree,
       routeRecognizerTree,
       fakeRequestTree,
-    ];
+      // tree is not always defined, so filter out if empty
+    ].filter(Boolean);
 
     return new MergeTrees(trees, {
       annotation: 'ember-cli-pretender: treeForVendor'


### PR DESCRIPTION
Without this change, my addon gets the following error on boot:

```
BroccoliMergeTrees (ember-cli-pretender: treeForVendor): Expected Broccoli node, got undefined for inputNodes[0]
TypeError: BroccoliMergeTrees (ember-cli-pretender: treeForVendor): Expected Broccoli node, got undefined for inputNodes[0]
    at BroccoliMergeTrees.Plugin (/Users/bgentry/Code/ember-apollo-client/node_modules/broccoli-plugin/index.js:23:13)
    at new BroccoliMergeTrees (/Users/bgentry/Code/ember-apollo-client/node_modules/broccoli-merge-trees/index.js:42:10)
    at Class.treeForVendor (/Users/bgentry/Code/ember-apollo-client/node_modules/ember-cli-pretender/index.js:47:12)
    at Class._treeFor (/Users/bgentry/Code/ember-apollo-client/node_modules/ember-cli/lib/models/addon.js:371:33)
    at Class.treeFor (/Users/bgentry/Code/ember-apollo-client/node_modules/ember-cli/lib/models/addon.js:339:21)
    at /Users/bgentry/Code/ember-apollo-client/node_modules/ember-cli/lib/broccoli/ember-app.js:499:20
    at Array.map (native)
    at EmberAddon.EmberApp.addonTreesFor (/Users/bgentry/Code/ember-apollo-client/node_modules/ember-cli/lib/broccoli/ember-app.js:497:30)
    at EmberAddon.EmberApp._processedVendorTree (/Users/bgentry/Code/ember-apollo-client/node_modules/ember-cli/lib/broccoli/ember-app.js:948:29)
    at EmberAddon.EmberApp._processedExternalTree (/Users/bgentry/Code/ember-apollo-client/node_modules/ember-cli/lib/broccoli/ember-app.js:978:21)
```

The problem seemed the same as was encountered in https://github.com/mike-north/ember-rx-shim/issues/1, so I fixed it by removing the base `tree` if it is undefined.