### PR TITLE
fix: use resolve with preserveSymlinks = false

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,14 @@ module.exports = {
 
       this._pretenderPath = resolve.sync('pretender');
       this._pretenderDir = path.dirname(this._pretenderPath);
-      this._routeRecognizerPath = resolve.sync('route-recognizer');
-      this._fakeRequestPath = resolve.sync('fake-xml-http-request');
-      this._abortControllerPath = resolve.sync('abortcontroller-polyfill/dist/abortcontroller-polyfill-only.js');
-      this._whatwgFetchPath = resolve.sync('@xg-wang/whatwg-fetch/dist/fetch.umd.js');
+      const resolveOptions = {
+        basedir: this._pretenderDir,
+        preserveSymlinks: process.env.NODE_PRESERVE_SYMLINKS === '1' || process.argv.indexOf('--preserve-symlinks') !== -1,
+      }
+      this._routeRecognizerPath = resolve.sync('route-recognizer', resolveOptions);
+      this._fakeRequestPath = resolve.sync('fake-xml-http-request', resolveOptions);
+      this._abortControllerPath = resolve.sync('abortcontroller-polyfill/dist/abortcontroller-polyfill-only.js', resolveOptions);
+      this._whatwgFetchPath = resolve.sync('@xg-wang/whatwg-fetch/dist/fetch.umd.js', resolveOptions);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ember-cli-babel": "^6.6.0",
     "fake-xml-http-request": "^2.0.0",
     "pretender": "^2.1.0",
-    "resolve": "^1.2.0",
+    "resolve": "^1.4.0",
     "route-recognizer": "^0.3.3"
   }
 }


### PR DESCRIPTION
resolve from version 2 will not preserve symlinks by default. Which is the way Node resolves dependencies by default.

This will make ember work with a symlinked node_modules layout.