### PR TITLE
Switch fetch polyfill to official version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "@xg-wang/whatwg-fetch": "^3.0.0",
     "abortcontroller-polyfill": "^1.1.9",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.0",
@@ -68,6 +67,7 @@
     "fake-xml-http-request": "^2.0.0",
     "pretender": "^2.1.0",
     "resolve": "^1.2.0",
-    "route-recognizer": "^0.3.3"
+    "route-recognizer": "^0.3.3",
+    "whatwg-fetch": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5957,6 +5957,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"


### PR DESCRIPTION
Now that the github fetch polyfill has pulled down the necessary PRs, we should move away from the forked version