### PR TITLE
Allow opt-out of fetch polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ var app = new EmberApp({
 });
 ```
 
+You can also opt out of including the fetch polyfill, if you do not need to run your tests in older browsers:
+
+```javascript
+var app = new EmberApp({
+  pretender: {
+    includeFetchPolyfill: false
+  }
+});
+```
+
 Nested Addon Usage Caveat
 =====
 

--- a/index.js
+++ b/index.js
@@ -63,10 +63,8 @@ module.exports = {
     });
   },
 
-  included: function included(app) {
-    if (app.app) {
-      app = app.app;
-    }
+  included: function included() {
+    var app = this._findApp();
     this.app = app;
 
     var opts = app.options.pretender || { enabled: app.tests };
@@ -75,9 +73,32 @@ module.exports = {
 
       app.import('vendor/fake-xml-http-request/' + path.basename(this._fakeRequestPath));
       app.import('vendor/route-recognizer/' + path.basename(this._routeRecognizerPath));
-      app.import('vendor/abortcontroller-polyfill/' + path.basename(this._abortControllerPath));
-      app.import('vendor/whatwg-fetch/' + path.basename(this._whatwgFetchPath));
+
+      var includeFetchPolyfill = opts.includeFetchPolyfill || typeof opts.includeFetchPolyfill === 'undefined';
+      if (includeFetchPolyfill) {
+        app.import('vendor/abortcontroller-polyfill/' + path.basename(this._abortControllerPath));
+        app.import('vendor/whatwg-fetch/' + path.basename(this._whatwgFetchPath));
+      }
+
       app.import('vendor/pretender/' + path.basename(this._pretenderPath));
+    }
+  },
+
+  _findApp() {
+    if (typeof this._findHost === 'function') {
+      return this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      // Keep iterating upward until we don't have a grandparent.
+      // Has to do this grandparent check because at some point we hit the project.
+      let app;
+      let current = this;
+      do {
+        app = current.app || this;
+      } while (current.parent && current.parent.parent && (current = current.parent));
+
+      return app;
     }
   },
 };


### PR DESCRIPTION
This PR adds a `includeFetchPolyfill` configuration option, which defaults to true, but can be disabled to not include the fetch polyfill.

IMHO, it would make sense to default this to `false`, and make this opt-in instead - but that would be a breaking change for a major release.

Fixes #66 