### PR TITLE
Replace `resolve.sync()` with `require.resolve()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,12 @@ module.exports = {
 
   _findPretenderPaths: function() {
     if (!this._pretenderPath) {
-      var resolve = require('resolve');
-
-      this._pretenderPath = resolve.sync('pretender');
+      this._pretenderPath = require.resolve('pretender');
       this._pretenderDir = path.dirname(this._pretenderPath);
-      this._routeRecognizerPath = resolve.sync('route-recognizer');
-      this._fakeRequestPath = resolve.sync('fake-xml-http-request');
-      this._abortControllerPath = resolve.sync('abortcontroller-polyfill/dist/abortcontroller-polyfill-only.js');
-      this._whatwgFetchPath = resolve.sync('@xg-wang/whatwg-fetch/dist/fetch.umd.js');
+      this._routeRecognizerPath = require.resolve('route-recognizer');
+      this._fakeRequestPath = require.resolve('fake-xml-http-request');
+      this._abortControllerPath = require.resolve('abortcontroller-polyfill/dist/abortcontroller-polyfill-only.js');
+      this._whatwgFetchPath = require.resolve('@xg-wang/whatwg-fetch/dist/fetch.umd.js');
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "ember-cli-babel": "^6.6.0",
     "fake-xml-http-request": "^2.0.0",
     "pretender": "^2.1.0",
-    "resolve": "^1.2.0",
     "route-recognizer": "^0.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5049,7 +5049,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
`resolve.sync()` resolves starting from the current working directory, but we actually would want to resolve these dependencies from `__dirname` since they are *our* dependencies, not the ones from the host app. `require.resolve()` correctly resolves using `__dirname` as the base path.

This change will also make this project compatible with Yarn PnP, as it was previously complaining about `pretender` not being a declared dependency of the host app.