### PR TITLE
ember-auto-import: Warn when it is a dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,29 @@ module.exports = {
     }
   },
 
+  _autoimportInfo() {
+    let chalk = require("chalk");
+    let info = chalk.yellow(`
+  INFORMATION (ember-cli-pretender)
+  ${chalk.inverse(
+    "ember-auto-import"
+  )} seems to be in your package dependencies.
+  As a result, you don't need pretender to be wrapped anymore.
+  You can install ${chalk.bold("pretender")} and remove ${chalk.bold(
+      "ember-cli-pretender"
+    )}.
+        `);
+    // eslint-disable-next-line no-console
+    console.log(info);
+  },
+
+  init() {
+    this._super.init && this._super.init.apply(this, arguments);
+    if (this.parent.dependencies()["ember-auto-import"]) {
+      this._autoimportInfo();
+    }
+  },
+
   treeForVendor: function(tree) {
     this._findPretenderPaths();
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "abortcontroller-polyfill": "^1.1.9",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.0",
+    "chalk": "^2.4.2",
     "ember-cli-babel": "^6.6.0",
     "fake-xml-http-request": "^2.0.0",
     "pretender": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,6 +1449,15 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"


### PR DESCRIPTION
In that case, user may consume pretender without the need of a
ember-cli-pretender.

![Capture d’écran 2019-05-29 à 13 09 27](https://user-images.githubusercontent.com/6677373/58552584-0ddbaa00-8213-11e9-9709-1e81eaf01de6.png)

See https://github.com/rwjblue/ember-cli-pretender/pull/71#issuecomment-496551231